### PR TITLE
chore: add skills for mixedbread search agent and mixedbread search agent harness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "name": "Mixedbread"
   },
   "metadata": {
-    "version": "1.0.0",
-    "description": "Agent skills for search, RAG, and document parsing with Mixedbread."
+    "version": "1.1.0",
+    "description": "Agent skills for search, RAG, parsing, completions, and model harnesses with Mixedbread."
   },
   "plugins": [
     {
@@ -25,6 +25,18 @@
       "name": "mixedbread-parsing",
       "description": "Parse documents, extract structured content, and run OCR using the Mixedbread Parsing API.",
       "source": "./skills/mixedbread-parsing",
+      "skills": ["./"]
+    },
+    {
+      "name": "mixedbread-search-agent",
+      "description": "Call Mixedbread's Toast-1 search model through the OpenAI-compatible Chat Completions API: auth, parameters, tool calls, streaming, stored conversations.",
+      "source": "./skills/mixedbread-search-agent",
+      "skills": ["./"]
+    },
+    {
+      "name": "mixedbread-search-agent-harness",
+      "description": "Build the loop around Mixedbread's Toast-1 search model: round budgets, parallel execution, evidence handles, pruning, terminals.",
+      "source": "./skills/mixedbread-search-agent-harness",
       "skills": ["./"]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "mixedbread-skills",
-  "description": "Agent skills for search, RAG, and document parsing with Mixedbread.",
-  "version": "1.0.0",
+  "description": "Agent skills for search, RAG, parsing, completions, and model harnesses with Mixedbread.",
+  "version": "1.1.0",
   "author": {
     "name": "Mixedbread"
   },
   "homepage": "https://skills.sh/mixedbread-ai/skills",
   "repository": "https://github.com/mixedbread-ai/skills",
   "license": "Apache-2.0",
-  "keywords": ["search", "rag", "parsing", "vector-search"]
+  "keywords": ["search", "rag", "parsing", "completions", "agent-harness", "vector-search"]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "support@mixedbread.com"
   },
   "metadata": {
-    "version": "1.0.0",
-    "description": "Agent skills for search, RAG, and document parsing with Mixedbread."
+    "version": "1.1.0",
+    "description": "Agent skills for search, RAG, parsing, completions, and model harnesses with Mixedbread."
   },
   "plugins": [
     {
@@ -29,7 +29,7 @@
       "description": "Build and query managed search indexes (Stores) using the Mixedbread Python and TypeScript SDKs.",
       "source": "./skills/mixedbread-search",
       "skills": ["./"],
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Mixedbread"
       },
@@ -53,6 +53,36 @@
       "license": "Apache-2.0",
       "logo": "public/logo_mb_square.svg",
       "keywords": ["parsing", "ocr", "pdf", "document-extraction"]
+    },
+    {
+      "name": "mixedbread-search-agent",
+      "description": "Call Mixedbread's Toast-1 search model through the OpenAI-compatible Chat Completions API: auth, parameters, tool calls, streaming, stored conversations.",
+      "source": "./skills/mixedbread-search-agent",
+      "skills": ["./"],
+      "version": "1.0.0",
+      "author": {
+        "name": "Mixedbread"
+      },
+      "homepage": "https://www.mixedbread.com/api-reference",
+      "repository": "https://github.com/mixedbread-ai/skills",
+      "license": "Apache-2.0",
+      "logo": "public/logo_mb_square.svg",
+      "keywords": ["search-agent", "model-api", "tool-calling", "retrieval-tools"]
+    },
+    {
+      "name": "mixedbread-search-agent-harness",
+      "description": "Build the loop around Mixedbread's Toast-1 search model: round budgets, parallel execution, evidence handles, pruning, terminals.",
+      "source": "./skills/mixedbread-search-agent-harness",
+      "skills": ["./"],
+      "version": "1.0.0",
+      "author": {
+        "name": "Mixedbread"
+      },
+      "homepage": "https://www.mixedbread.com/docs",
+      "repository": "https://github.com/mixedbread-ai/skills",
+      "license": "Apache-2.0",
+      "logo": "public/logo_mb_square.svg",
+      "keywords": ["search-model", "agent-harness", "tool-calling", "search-agent"]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,20 +8,30 @@ Agent skills for building search, RAG, and document parsing with [Mixedbread](ht
   - `skills/mxbai-cli/` — CLI tool usage
   - `skills/mixedbread-search/` — Stores API & SDKs
   - `skills/mixedbread-parsing/` — Parsing API & OCR
+  - `skills/mixedbread-search-agent/` — Toast-1 completions API, tool contracts & Stores wiring
+  - `skills/mixedbread-search-agent-harness/` — Custom search-model harness design
 - `.claude-plugin/` — Claude Code plugin configuration
 - `.cursor-plugin/` — Cursor plugin configuration
 - `.mcp.json` — MCP server configuration
 - `gemini-extension.json` — Gemini CLI extension configuration
 - `agents/AGENTS.md` — Fallback instructions for Codex/OpenAI agents
 - `SKILL_TREE.md` — Navigable index of all skills
+- `benchmark.sh` — Blind A/B comparison of agent output with and without the skills
 
 ## Conventions
 
 - Each skill's `SKILL.md` uses YAML frontmatter with `name` and `description` fields
 - The `description` field determines when the agent activates the skill — write it as a trigger condition
-- SKILL.md contains decision trees, workflows, severity-rated rules, anti-patterns, and troubleshooting
-- API reference docs are not bundled — agents fetch them at runtime via MCP, context7, or docs URLs (e.g., `https://www.mixedbread.com/docs.md`)
-- Code examples use both Python (`mixedbread` package) and TypeScript (`@mixedbread/sdk`)
+- Open with docs links and close with a Troubleshooting table. Everything between is up to the skill — name sections after what they actually cover rather than forcing a fixed template
+- Do not group guidance by severity. Where a reference table already carries the constraint, let it; where the constraint is a mistake to avoid, state it as a flat "Don't" list
+- Prefer tables and code over prose. State the fact and the fix; cut the explanation of why unless the agent gets it wrong without it
+- Keep `SKILL.md` under 500 lines. Past that, move detail into `references/` and say in the pointer *when* to read each file
+- Do not duplicate broad public API reference docs. Bundle focused behavioral references when a skill depends on non-obvious product or harness contracts, and link public docs for the general surface.
+- Keep the search-model guidance backend-agnostic and isolate the Mixedbread wiring in its own reference. The model brings no retrieval of its own, so a skill that only shows Stores-backed tools teaches the wrong contract.
+- Skills install as separate plugins, so a relative path into a sibling skill does not resolve. When two skills need the same reference — `tool-contracts.md` is the current case — duplicate the file in full rather than summarizing it in one of them, and update both copies together.
+- The served model id is `toast-1`.
+- SDK-facing examples normally cover both Python and TypeScript. Stores and parsing use the first-party SDKs (`mixedbread`, `@mixedbread/sdk`); the search agent uses the official OpenAI clients against Mixedbread's base URL. Harness-internal guidance may stay Python.
+- The two OpenAI clients carry Mixedbread's protocol extensions differently — Python requires `extra_body`, Node takes them inline with a type cast — so write each language reference from a verified example rather than translating the other.
 - API base URL: `https://api.mixedbread.com/`
 - API key env var: `MXBAI_API_KEY`
 - CLI tool: `mxbai` (installed via `npm install -g @mixedbread/cli`)
@@ -35,6 +45,22 @@ Agent skills for building search, RAG, and document parsing with [Mixedbread](ht
 5. Update the skills table in `README.md`
 6. Update `agents/AGENTS.md` with the new skill entry
 7. Update `SKILL_TREE.md` with the new skill
+8. Bump the marketplace-level minor version when adding a skill
+
+## Testing a Skill
+
+- **Run the examples as written.** A skill can be internally consistent and still assert things the API no longer does. A snippet that raises `TypeError` on an unsupported keyword is a defect no amount of review catches.
+- **Compare with and without the skill.** `./benchmark.sh --model sonnet` runs a blind LLM-judge comparison of full task output with and without the plugin. Anything that comes out the same either way is measuring the base model, not the skill.
+
+Feed failures back as gotchas rather than as new rules. When an agent gets something wrong, the fix is usually one concrete correction in the skill's rules or troubleshooting table, not another paragraph of prose.
+
+## Distribution and Versioning
+
+- `main` is the rolling release source for `npx skills add mixedbread-ai/skills`; this repository does not publish an npm package or create GitHub releases automatically.
+- Existing installations update through `npx skills check` and `npx skills update`.
+- New marketplace plugins start at `1.0.0`.
+- Bump an existing plugin's semantic version whenever its shipped skill content changes: patch for fixes, minor for backward-compatible capability additions, and major for breaking workflow changes.
+- Bump the marketplace-level version when its plugin catalog or overall packaged capabilities change.
 
 ## Key Links
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p><em>All Mixedbread Skills you ever need.</em></p>
 </div>
 
-Agent skills for building search, RAG, and document parsing with [Mixedbread](https://www.mixedbread.com). Compatible with Claude Code, Cursor, Codex, Gemini CLI, and [20+ other agents](https://skills.sh/).
+Agent skills for building search, RAG, document parsing, search-grounded completions, and agent harnesses with [Mixedbread](https://www.mixedbread.com). Compatible with Claude Code, Cursor, Codex, Gemini CLI, and [20+ other agents](https://skills.sh/).
 
 ## Installation
 
@@ -24,6 +24,15 @@ npx skills add mixedbread-ai/skills -g
 
 Browse on the registry: [skills.sh/mixedbread-ai/skills](https://skills.sh/mixedbread-ai/skills)
 
+### Updating
+
+Installations are snapshots of the skill source at installation time. To check for and install updates from the repository:
+
+```bash
+npx skills check
+npx skills update
+```
+
 ### Platform-Specific Alternatives
 
 <details>
@@ -33,13 +42,15 @@ Browse on the registry: [skills.sh/mixedbread-ai/skills](https://skills.sh/mixed
 claude install-skill mixedbread-ai/skills mxbai-cli
 claude install-skill mixedbread-ai/skills mixedbread-search
 claude install-skill mixedbread-ai/skills mixedbread-parsing
+claude install-skill mixedbread-ai/skills mixedbread-search-agent
+claude install-skill mixedbread-ai/skills mixedbread-search-agent-harness
 ```
 </details>
 
 <details>
 <summary>Cursor</summary>
 
-This repo ships as a Cursor marketplace with three separately-installable plugins (`mxbai-cli`, `mixedbread-search`, `mixedbread-parsing`). Install from the [Cursor marketplace](https://cursor.com/marketplace), or test locally by cloning into `~/.cursor/plugins/local`:
+This repo ships as a Cursor marketplace with five separately-installable plugins (`mxbai-cli`, `mixedbread-search`, `mixedbread-parsing`, `mixedbread-search-agent`, `mixedbread-search-agent-harness`). Install from the [Cursor marketplace](https://cursor.com/marketplace), or test locally by cloning into `~/.cursor/plugins/local`:
 
 ```bash
 git clone https://github.com/mixedbread-ai/skills ~/.cursor/plugins/local/mixedbread-skills
@@ -69,6 +80,8 @@ Reference the `gemini-extension.json` for extension configuration, or use the `.
 | [`mxbai-cli`](skills/mxbai-cli/SKILL.md) | Manage stores, upload files, search, and sync using the `mxbai` CLI |
 | [`mixedbread-search`](skills/mixedbread-search/SKILL.md) | Create and search managed knowledge bases using the Stores API and SDKs |
 | [`mixedbread-parsing`](skills/mixedbread-parsing/SKILL.md) | Parse documents, extract structured content, and run OCR using the Parsing API |
+| [`mixedbread-search-agent`](skills/mixedbread-search-agent/SKILL.md) | Call Mixedbread's Toast-1 search model through the Chat Completions API |
+| [`mixedbread-search-agent-harness`](skills/mixedbread-search-agent-harness/SKILL.md) | Build the loop around Toast-1: rounds, parallelism, evidence handles, pruning |
 
 See [SKILL_TREE.md](SKILL_TREE.md) for a navigable index of all skills.
 
@@ -88,7 +101,9 @@ mixedbread-skills/
 └── skills/
     ├── mxbai-cli/           # CLI tool usage
     ├── mixedbread-search/   # Stores API & SDKs
-    └── mixedbread-parsing/  # Parsing API & OCR
+    ├── mixedbread-parsing/  # Parsing API & OCR
+    ├── mixedbread-search-agent/ # Chat Completions API, tool contracts & Stores wiring
+    └── mixedbread-search-agent-harness/ # Custom search-model harness design
 ```
 
 ## Links

--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -8,6 +8,13 @@ Build and query managed search indexes.
 
 - **[mixedbread-search](skills/mixedbread-search/SKILL.md)** — Create stores, upload documents, search, and ask questions using the Python and TypeScript SDKs.
 
+## Completions & Agents
+
+Build search-grounded chat and custom search-agent runtimes.
+
+- **[mixedbread-search-agent](skills/mixedbread-search-agent/SKILL.md)** — Call Mixedbread's Toast-1 search model through the Chat Completions API: auth, parameters, tool calls, structured terminals, streaming, and stored conversations.
+- **[mixedbread-search-agent-harness](skills/mixedbread-search-agent-harness/SKILL.md)** — Build the loop: round budgets, parallel execution, stable evidence handles, pruning, terminal tools, and evaluation.
+
 ## Parsing
 
 Parse documents, extract structured content, and run OCR.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -16,6 +16,14 @@ Build and query managed search indexes (Stores) using the Mixedbread Python and 
 Parse documents, extract structured content, and run OCR using the Mixedbread Parsing API. Supports PDFs, Word documents, PowerPoint presentations, and images. Extract tables, forms, figures, and other elements with bounding boxes and confidence scores.
 - Skill file: [skills/mixedbread-parsing/SKILL.md](../skills/mixedbread-parsing/SKILL.md)
 
+### mixedbread-search-agent
+Call Mixedbread's Toast-1 search model through the OpenAI-compatible Chat Completions API: authentication, request parameters, response shape, declaring function tools and answering tool calls, structured terminals, streaming, and stored conversations. Includes backend-agnostic tool contracts and the Mixedbread Stores wiring.
+- Skill file: [skills/mixedbread-search-agent/SKILL.md](../skills/mixedbread-search-agent/SKILL.md)
+
+### mixedbread-search-agent-harness
+Build the loop around Mixedbread's Toast-1 search model: bounded round budgets, parallel tool execution, stable evidence handles, context pruning, terminal tools, orchestration, and evaluation.
+- Skill file: [skills/mixedbread-search-agent-harness/SKILL.md](../skills/mixedbread-search-agent-harness/SKILL.md)
+
 
 ## Setup
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mixedbread-skills",
-  "description": "Agent skills for search, RAG, and document parsing with Mixedbread.",
+  "description": "Agent skills for search, RAG, parsing, completions, and model harnesses with Mixedbread.",
   "mcp_servers": [
     {
       "uri": "https://www.mcp.mixedbread.com/api/mcp"

--- a/skills/mixedbread-search-agent-harness/SKILL.md
+++ b/skills/mixedbread-search-agent-harness/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: mixedbread-search-agent-harness
+description: >-
+  Design, implement, review, or tune a custom harness for Mixedbread's Toast-1 search model through
+  the OpenAI-compatible Completions API. Use when building bounded search-agent loops, custom
+  retrieval or answer tools, parallel tool execution, evidence ranking and reporting, stable
+  chunk-handle registries, context pruning, payload budgets, or evaluations for the model as a
+  lookup subagent.
+---
+
+# Mixedbread Search Agent Harness
+
+Toast-1 is Mixedbread's search model: a deep search and lookup agent trained to gather multi-hop evidence and submit ranked results. Build the harness for exploration, tool clarity, stable evidence identity, and bounded context — not for free-form general reasoning.
+
+Scope: everything above one request — rounds, concurrency, evidence identity, context, termination. Use the loop as a fast search sub-agent for an orchestrator doing knowledge work, or as a standalone searcher. Orchestration remains outside this harness. For the API surface underneath (auth, request parameters, response shape, streaming, stored conversations, SDK extension fields), use the `mixedbread-search-agent` skill.
+
+Docs: https://www.mixedbread.com/docs/agent/build-your-own-harness
+Model card: https://www.mixedbread.com/docs/agent/models
+Agent-readable docs: https://www.mixedbread.com/docs/llms.txt
+
+## The loop
+
+The API is stateless. Send a messages list plus tool schemas; the model returns text or tool calls. On `finish_reason="tool_calls"`, execute the calls, append **one tool message per call**, and resend the whole history. Build that exchange to these rules:
+
+- **Budget rounds, terminal included.** The model is trained to work within a bounded number of turns, so state the boundary in the prompt instead of only enforcing it in code. On the final round, narrow the tool list to the terminal and force it by name; otherwise the model ends in prose and returns no structured payload. Count the terminal round: 4 rounds gives the model three searches.
+- **Cap parallel calls, answer all of them.** The model fans out by design, and a round costs only the latency of its slowest call. Execute accepted calls concurrently, and emit a tool message for *rejected* calls too — an unanswered `tool_call_id` makes the next request invalid.
+- **Budget payloads.** Clip result text as it enters the history, and bound the round as a whole. Eight uncapped returns in one round cross the input limit on their own.
+- **Manage context in the harness.** Nothing prunes for you. Prune the message list you resend rather than summarizing it, and tell the model when it is over budget — see [Context management](#context-management).
+- **Return every tool result as data.** A tool that raises leaves its call unanswered and breaks the next request; return `{"error": "..."}` so the model corrects itself on the following round.
+
+```python
+import asyncio
+import json
+
+
+async def run_episode(client, query: str) -> dict | str | None:
+    messages = [{"role": "user", "content": query}]
+
+    for round_index in range(MAX_ROUNDS):           # the terminal round is one of these
+        final_round = round_index == MAX_ROUNDS - 1
+        completion = await client.chat.completions.create(
+            model="toast-1",
+            messages=messages,
+            tools=[TERMINAL] if final_round else TOOLS,
+            tool_choice=(
+                {"type": "function", "function": {"name": TERMINAL_NAME}}
+                if final_round
+                else "auto"
+            ),
+            parallel_tool_calls=not final_round,
+            temperature=0.7,
+            top_p=0.95,
+            max_completion_tokens=4096,
+            store=False,
+        )
+        message = completion.choices[0].message
+        if not message.tool_calls:
+            return message.content                  # finish_reason="stop": the run is done
+        if final_round:
+            if (
+                len(message.tool_calls) != 1
+                or message.tool_calls[0].function.name != TERMINAL_NAME
+            ):
+                raise RuntimeError("final round did not return exactly one terminal call")
+            return validate_terminal(message.tool_calls[0])
+
+        messages.append(message.model_dump(exclude_none=True))
+
+        accepted = message.tool_calls[:MAX_PARALLEL_CALLS]
+        results = await asyncio.gather(*(execute(call) for call in accepted))
+        rejected = [over_cap_error(call) for call in message.tool_calls[MAX_PARALLEL_CALLS:]]
+
+        # One tool message per emitted call, in the model's original call order.
+        for call, result in zip(message.tool_calls, [*results, *rejected]):
+            messages.append(
+                {"role": "tool", "tool_call_id": call.id, "content": json.dumps(clip(result))}
+            )
+
+        messages = prune_if_over_budget(messages)   # edit the list you resend
+
+    raise RuntimeError("round budget exhausted without a terminal")
+```
+
+Bootstrap the episode: fetch metadata facets and one seed search concurrently before round 1 and inject both as tool results, so the model starts oriented without spending a round on it. Read [architecture.md](references/architecture.md) for round-by-round mechanics and [python-loop.md](references/python-loop.md) for the full implementation.
+
+## Operating envelope
+
+| Knob | Start at | Notes |
+|------|----------|-------|
+| Rounds | 4 total, terminal included | Soft; the model handles 8, 12, or more |
+| Parallel calls per round | 8 | Pruning counts toward the cap |
+| `temperature` / `top_p` | 0.7 / 0.95 | Trained defaults |
+| Thinking | Disabled | Trained and served without it; not optional |
+| Sequence length | 131,072 tokens | Keep every request's input under ~130,000 |
+| Generation | Capped at 4,096 tokens | Size `max_completion_tokens` to the terminal payload |
+| Prune trigger | ~50,000 prompt tokens | Budget notice fires every round past it |
+| Hard prompt ceiling | ~100,000 tokens | Headroom, so a growing round cannot overshoot |
+| Chunk clip | ~2,000 tokens | 4× that for expansion tools |
+| Terminal retries | 2, then fail | Never substitute your own ranking |
+
+Hold a ceiling with real headroom instead of aiming at the limit: overflow returns an opaque HTTP 500, not a context-length error, so no reactive recovery is possible. Track `usage.prompt_tokens` from each completion to measure how fast the history grows.
+
+To grow exploration, **widen the round before deepening the loop**. A round already costs the latency of its slowest call, so parallel width is nearly free; an extra round costs a generation plus the prompt growth that follows it.
+
+## Components
+
+| Component | Owns |
+|-----------|------|
+| Generation adapter | Messages, tool schemas, sampling, final-turn flag. Keeps harness-only settings off the wire |
+| Tool registry / executor | Name → schema + implementation, argument validation, per-round cap, concurrent execution, structured errors |
+| Evidence registry | Identity → stable `chunk_id` / `document_id`; tracks seen, visible, pruned, restored |
+| Context budgeter | Token counting, clipping, per-call and per-round budgets, redaction of pruned payloads |
+| Episode controller | Bootstrap, round loop, termination, terminal validation and retry |
+
+## Evidence identity
+
+Assign a short handle (`c12`, not a UUID) at first sight and never reassign it. For better search diversity, consider deduplicating ordinary search results against evidence already shown to the agent; the backend does not do cross-call deduplication for you.
+
+Accept only handles you actually emitted in expansion, pruning, and terminal tools. Validate the final submission against the registry rather than trusting the enum, and never silently substitute a harness ranking for the model's.
+
+## Context management
+
+- **Prune, do not summarize.** Inference is optimized for a stable prompt prefix with stale payloads removed. A summary rewrites the prefix and pays generation latency to lose evidence detail.
+- **Tell the model.** State the pruning contract in the system prompt, then append a budget notice every round past the trigger: the estimated token count, the tool to call, that pruning may run **in parallel** with searches, and that finishing is the other valid answer. Copy the exact message from [reference-harness.md](references/reference-harness.md).
+- **Preserve handles after pruning.** Remove content, not identity.
+- **Keep the prefix byte-stable.** A clock time or a full-precision score in the prompt changes every request and invalidates the cache on its own.
+- **Never combine pruning with `previous_completion_id` in one turn.** That field restores context only while the messages extend the stored history unchanged; a pruned history silently falls back to text-only.
+
+## Tool design
+
+Write descriptions as operating instructions: name the matching mechanism (semantic, BM25, RE2 regex, metadata filter, lookup), the preferred input form, and one contrasting misuse. Keep arguments flat, snake_case, and JSON-native; use `Literal`/enum for closed modes; publish bounds in the description. In Python, docstrings become tool descriptions and `Annotated` strings become parameter descriptions.
+
+Return JSON objects carrying the echoed query, candidate count, and results — never prose. Read [tool-contracts.md](references/tool-contracts.md) for the full contracts.
+
+## Evaluation
+
+Record per episode: rounds and calls per round; prompt, completion, and peak input tokens as reported by `usage`; per-tool latency and the slowest call per round; queries, result counts, duplicate suppression, clipping, truncation, pruning; rounds that passed the budget trigger without pruning or submitting; invalid arguments, structured recoveries, forced-terminal attempts, unresolved IDs; final ranked IDs, scores, and nDCG/recall.
+
+Compare on fixed queries and fixed corpus snapshots. Raise depth, width, or payload limits one dimension at a time.
+
+## Don't
+
+- Don't name a harness tool `submit_answer`. Reserved — HTTP 422.
+- Don't detect termination by tool name. A finished run is `finish_reason="stop"` with content; a harness terminal only appears when forced by name.
+- Don't let a tool exception escape the executor, or leave an assistant tool call without a matching tool message.
+- Don't substitute a harness ranking for the model's submission. Validate against the registry, retry bounded, then fail.
+- Don't enable thinking, or build logic on `reasoning_content`.
+- Don't reach for the terminal with prompt wording alone. `tool_choice="required"` produces no visible call either — force it by name.
+- Don't prune silently, and don't wait for the ceiling. A budget notice missing "this may run in parallel" costs a whole search round.
+- Don't execute independent calls serially.
+- Don't leave payloads uncapped. Eight uncapped returns in one round fill the context before the third.
+- Don't count the terminal turn outside the round budget. At 3 rounds a searcher gets two searches.
+- Don't attach an instruction to the round label. "Search round 2 of max 4" as bare state; a nudge to submit teaches the model to wait for the countdown.
+- Don't let expansion tools return as little text as search. At ~4× the clip they are worth calling; below that they are not.
+- Don't let the model filter on unconfirmed metadata, or rank on fields not confirmed numeric.
+- Don't reorder tool messages relative to the model's call order, even when execution finishes out of order.
+- Don't force the model to consume every round after it has enough evidence.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Loop exhausts its round budget every episode | Termination detected by tool name | Treat `finish_reason="stop"` with content as the ending |
+| Opaque HTTP 500 mid-episode | Input over the sequence length | Hold a hard ceiling near 100,000 and clip round payloads into it |
+| Terminal returns prose | Not forced by name | `tool_choice={"type": "function", "function": {"name": ...}}` |
+| Model ignores the context limit | No budget signal reaches it | Contract in the system prompt + a per-round notice naming the token count |
+| A budget notice costs a whole search round | Notice does not say pruning can run in parallel | Say it explicitly, and note that pruning counts toward the call cap |
+| Latency spikes with no quality gain | Serial execution, or depth added instead of width | Run calls concurrently; raise parallel calls before rounds |
+| Prefix cache hit rate collapses | Timestamp, full-precision score, or summarized history in the prompt | UTC date only, round scores, prune instead of summarizing |
+| Context full after 2-3 rounds | Uncapped tool payloads | Clip to ~2,000 tokens per result and bound the round |
+| Model re-searches ground it covered | Results carry no stable handles | Assign short handles at first sight and never reassign |
+| Model re-requests pruned evidence | Prune semantics never stated | Say whether pruned chunks can resurface and which tool restores them |
+| One large payload starves the round | No per-call budget | Spread-truncate in presentation order with a per-item floor |
+
+## References
+
+- [architecture.md](references/architecture.md) — read before designing or reviewing a loop: round choreography, parallel execution, context management, and evidence identity.
+- [tool-contracts.md](references/tool-contracts.md) — read before defining tool schemas or result envelopes.
+- [python-loop.md](references/python-loop.md) — read when implementing the loop with the OpenAI Python client.
+- [reference-harness.md](references/reference-harness.md) — read when choosing budgets, prompts, or pruning policy, or when a run burns rounds, clips evidence, or ignores the context limit. What Mixedbread's production harness does, and why.

--- a/skills/mixedbread-search-agent-harness/agents/openai.yaml
+++ b/skills/mixedbread-search-agent-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mixedbread Search Agent Harness"
+  short_description: "Build the loop around Toast-1"
+  default_prompt: "Use $mixedbread-search-agent-harness to design a bounded, parallel harness for Mixedbread's Toast-1 search model."

--- a/skills/mixedbread-search-agent-harness/references/architecture.md
+++ b/skills/mixedbread-search-agent-harness/references/architecture.md
@@ -1,0 +1,52 @@
+# Harness architecture
+
+Round-by-round mechanics for a search-model harness. Components, budgets, and rules live in SKILL.md; this is how a round actually runs. The loop can serve as a fast search sub-agent doing knowledge work for any orchestrator; orchestration itself stays outside the harness.
+
+## Round choreography
+
+Before the final round:
+
+1. Build non-terminal tools. For a structured deliverable, also append the terminal with evidence-ID enums derived from currently visible evidence.
+2. Apply the configured context-management policy when its pressure threshold is crossed. For the recommended pruning policy, append the budget notice before requesting the turn.
+3. Request one turn with `tool_choice="auto"` and parallel calls enabled.
+4. Content with no calls → the run finished; accept it when prose is the deliverable.
+5. Terminal as the only call → validate and finish.
+6. Terminal mixed with other calls → return a structured invalid-terminal error, or reject the turn per policy.
+7. Cap accepted non-terminal calls, execute concurrently, append one result message per emitted call, and use structured errors for excess or unknown calls.
+8. Clip combined payloads to the remaining prompt headroom.
+9. Stop early when the evidence suffices. A round ceiling is not a target.
+
+Final round:
+
+1. Remove retrieval tools. Prose → send no tools at all. Structured → offer only the terminal and force it by name.
+2. Append: "Do not search further. Make exactly one terminal call with no parallel calls."
+3. Return the text directly, or validate submitted IDs, cardinality, ordering fields, and score range.
+4. Retry an invalid payload a small fixed number of times without reopening retrieval.
+
+## Parallel execution
+
+| Concern | Approach |
+|---------|----------|
+| Independent calls | Async-native I/O with `gather`/task groups |
+| Message ordering | Preserve the model's call order even when completion order differs |
+| Payload allocation | Water-fill: small payloads keep full size, remaining budget splits among larger siblings |
+| Shared state | Duplicate suppression and ID assignment must be concurrency-safe |
+| Throughput | Track provider QPS separately from model-visible call width |
+| Cancellation | Cancel in-flight calls when the episode is cancelled |
+
+## Context management semantics
+
+Prefer pruning stale payloads because it preserves a stable prompt prefix and evidence identities. If an application uses compaction instead, define its identity, restoration, and cache behavior explicitly rather than silently changing the history.
+
+On prune:
+
+- remove matching content from old tool-result messages;
+- retain the registry entries and IDs;
+- allow an explicit expansion call to restore the content;
+- permit the terminal to rank a pruned ID, since the model already evaluated it.
+
+This differs from truncation. A result dropped **before** the model ever saw it must leave the visible registry entirely and may be returned by a later search.
+
+## Duplicate suppression
+
+As an independent backend optimization, optionally suppress chunks already shown to the agent so repeated queries produce more diverse evidence. This is recommended for search quality but is not part of pruning semantics and is not required for a valid harness.

--- a/skills/mixedbread-search-agent-harness/references/python-loop.md
+++ b/skills/mixedbread-search-agent-harness/references/python-loop.md
@@ -1,0 +1,429 @@
+# Python loop pattern
+
+This pattern shows the search-model-specific control flow. Adapt tool implementations and endpoint configuration to the application.
+
+## Contents
+
+- [Completion call](#completion-call)
+- [Async round executor](#async-round-executor)
+- [Episode controller](#episode-controller)
+- [Evidence registry invariants](#evidence-registry-invariants)
+
+## Completion call
+
+```python
+import os
+
+from openai import AsyncOpenAI
+
+
+client = AsyncOpenAI(
+    base_url="https://api.mixedbread.com/v1",
+    api_key=os.environ["MXBAI_API_KEY"],
+)
+
+# Any name except `submit_answer`, which the endpoint reserves.
+TERMINAL_TOOL_NAME = "report_evidence"
+
+
+def terminal_tool_schema(visible_chunk_ids: list[str]) -> dict:
+    """Harness terminal; define one only when the caller needs structured evidence."""
+    return {
+        "type": "function",
+        "function": {
+            "name": TERMINAL_TOOL_NAME,
+            "description": (
+                "Submit the complete evidence-grounded answer and end the episode. "
+                "Call this exactly once and never beside another tool."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "answer": {
+                        "type": "string",
+                        "description": "Complete final answer ready to show to the user.",
+                    },
+                    "ranking_strategy": {
+                        "type": "string",
+                        "description": "How evidence relevance and constraints determined the order.",
+                    },
+                    "chunks": {
+                        "type": "array",
+                        "description": "Ranked evidence, most relevant first; do not pad weak results.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "chunk_id": {
+                                    "type": "string",
+                                    "enum": visible_chunk_ids,
+                                },
+                                "relevance_score": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                },
+                            },
+                            "required": ["chunk_id", "relevance_score"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["answer", "ranking_strategy", "chunks"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+async def complete(
+    messages: list[dict],
+    tools: list[dict],
+    *,
+    final_round: bool = False,
+    terminal_tool: dict | None = None,
+):
+    """Complete one round; `tools` contains only non-terminal client functions."""
+    if any(
+        tool.get("function", {}).get("name") == "submit_answer" for tool in tools
+    ):
+        raise ValueError("submit_answer is a reserved tool name")
+
+    request = dict(
+        model="toast-1",
+        messages=messages,
+        temperature=0.7,
+        top_p=0.95,
+        max_completion_tokens=4096,
+        store=False,
+    )
+    if final_round and terminal_tool:
+        request.update(
+            tools=[terminal_tool],
+            tool_choice={
+                "type": "function",
+                "function": {"name": TERMINAL_TOOL_NAME},
+            },
+            parallel_tool_calls=False,
+        )
+    elif not final_round:
+        request.update(
+            tools=[*tools, *([terminal_tool] if terminal_tool else [])],
+            tool_choice="auto",
+            parallel_tool_calls=True,
+        )
+
+    # A prose-only final round intentionally omits tools and tool_choice.
+    return await client.chat.completions.create(**request)
+```
+
+Every retrieval tool is a client-executed `function` the harness runs itself. Pass only non-terminal schemas in `tools` and let `complete()` attach the terminal.
+
+Two facts shape the terminal design:
+
+- `submit_answer` is a reserved tool name: declaring it fails the request with HTTP 422 (`'submit_answer' is reserved`). Name the harness terminal anything else; `TERMINAL_TOOL_NAME` above exists so the schema, the reminder text, and the executor cannot drift apart.
+- The model's default ending is ordinary assistant text, so a finished run never arrives as a `tool_call`. A controller that recognizes termination only by tool name will exhaust its round budget and fall through to the failure branch. Treat a `finish_reason="stop"` message with `content` as a terminal.
+
+Before calling `complete(..., final_round=True)`, append the final-round instruction to the controller's persistent history; do not add it to a request-local copy that disappears before a correction attempt. When the deliverable is prose, pass `terminal_tool=None` and omit `tools`, `tool_choice`, and `parallel_tool_calls` entirely; do not send `tools=[]` with `tool_choice="none"`, because OpenAI-compatible backends may reject that combination. When the caller needs ranked evidence, pass a terminal schema built from currently visible evidence IDs — and force it by name on the final round. Named forcing is not optional: prompt instructions alone lose to a plain prose ending most of the time, and `tool_choice="required"` still returns assistant text with no visible call.
+
+Mixedbread's completion service keeps thinking disabled. If a harness also targets a self-hosted copy of the checkpoint, preserve that behavior explicitly there:
+
+```python
+extra_body={
+    "chat_template_kwargs": {
+        "enable_thinking": False,
+        "preserve_thinking": False,
+    }
+}
+```
+
+Do not pass process policy such as `max_rounds`, pruning thresholds, or retry counts as model sampling fields.
+
+The model is served at a sequence length of 131,072 tokens and generation is capped at 4,096 per completion, so `max_completion_tokens` above 4,096 buys nothing. Keep each request's input under ~130,000: the reservation still comes out of the same sequence budget, and a prompt that fits with 4,096 reserved can fail once the reservation grows.
+
+Overflow returns an opaque HTTP 500 rather than a context-length error, so the controller cannot detect it after the fact — hold a ceiling with real headroom and clip round payloads into it.
+
+## Async round executor
+
+```python
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+
+MAX_ROUNDS = 4                 # terminal round included
+MAX_TERMINAL_CORRECTIONS = 2   # retries after the first failed ending
+MAX_PARALLEL_CALLS = 8
+PRUNE_REMINDER_TOKENS = 50_000
+HARD_PROMPT_TOKENS = 100_000
+MODEL_SEQUENCE_TOKENS = 131_072  # served sequence length; keep input under ~130k
+RESERVED_OUTPUT_TOKENS = 4_096  # subtracted from the prompt ceiling
+
+# The harness owns pruning; Mixedbread ships no pruning tool. Name it whatever
+# suits the domain and keep the name consistent across the schema, the reminder,
+# and the executor.
+PRUNE_TOOL_NAME = "discard_evidence"
+
+ToolFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+@dataclass
+class Episode:
+    messages: list[dict[str, Any]]
+    tools: dict[str, ToolFn]
+    evidence: "EvidenceRegistry"
+    trace: list[dict[str, Any]] = field(default_factory=list)
+
+
+async def safe_execute(name: str, arguments: str, fn: ToolFn) -> dict[str, Any]:
+    try:
+        parsed = json.loads(arguments or "{}")
+        if not isinstance(parsed, dict):
+            raise ValueError("arguments must be a JSON object")
+        result = await fn(parsed)
+        return result if isinstance(result, dict) else {"error": "tool must return an object"}
+    except ValueError as exc:
+        return {"error": str(exc), "code": "invalid_arguments", "retryable": True}
+    except PermissionError as exc:
+        return {"error": str(exc), "code": "permission_denied", "retryable": False}
+    except Exception as exc:
+        return {"error": str(exc), "code": "server_error", "retryable": True}
+
+
+async def execute_round(episode: Episode, calls: list[Any]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any] | None] = [None] * len(calls)
+    executable: list[tuple[int, Any, ToolFn]] = []
+
+    for index, call in enumerate(calls):
+        name = call.function.name
+        if index >= MAX_PARALLEL_CALLS:
+            results[index] = {
+                "error": f"round limit is {MAX_PARALLEL_CALLS} calls",
+                "code": "parallel_call_limit_exceeded",
+                "retryable": True,
+            }
+            continue
+
+        fn = episode.tools.get(name)
+        if fn is None:
+            results[index] = {
+                "error": f"unknown tool: {name}",
+                "code": "unknown_tool",
+                "retryable": True,
+            }
+            continue
+
+        executable.append((index, call, fn))
+
+    executed = await asyncio.gather(
+        *[
+            safe_execute(call.function.name, call.function.arguments, fn)
+            for _, call, fn in executable
+        ]
+    )
+    for (index, _, _), result in zip(executable, executed, strict=True):
+        results[index] = result
+
+    # Emit exactly one tool message per model call, including rejected calls.
+    tool_messages = []
+    for call, result in zip(calls, results, strict=True):
+        if result is None:
+            raise AssertionError("missing tool result")
+        tool_messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": json.dumps(result, ensure_ascii=False),
+            }
+        )
+    return tool_messages
+```
+
+Keep every emitted call in the assistant transcript and return one matching tool message for each. Execute known calls only within the first `MAX_PARALLEL_CALLS` emitted positions; represent excess and unknown calls as structured errors so the next completion request remains protocol-valid and the model can recover.
+
+## Episode controller
+
+```python
+def final_round_message(structured_terminal: bool) -> dict[str, str]:
+    instruction = (
+        "Make exactly one terminal call with no other or parallel calls."
+        if structured_terminal
+        else "Return the final answer now."
+    )
+    return {
+        "role": "user",
+        "content": (
+            "You have reached the search limit. Do not search further. "
+            f"{instruction}"
+        ),
+    }
+
+
+def terminal_error_messages(message: Any, calls: list[Any], error: str) -> list[dict[str, Any]]:
+    """Keep a rejected terminal turn protocol-complete for a correction request."""
+    return [
+        message.model_dump(exclude_none=True),
+        *[
+            {
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": json.dumps(
+                    {
+                        "error": error,
+                        "code": "invalid_terminal",
+                        "retryable": True,
+                    }
+                ),
+            }
+            for call in calls
+        ],
+    ]
+
+
+async def run_episode(query: str, *, structured_terminal: bool = False) -> dict[str, Any]:
+    episode = Episode(
+        messages=build_initial_messages(query),
+        tools=tool_implementations(),
+        evidence=EvidenceRegistry(),
+    )
+
+    force_terminal = False
+    terminal_corrections = 0
+
+    for attempt_index in range(MAX_ROUNDS + MAX_TERMINAL_CORRECTIONS):
+        final_round = force_terminal or attempt_index == MAX_ROUNDS - 1
+
+        # Persist the instruction that this response answers. If the response is
+        # invalid, replaying it with the assistant/tool messages keeps role order
+        # valid for the next correction request.
+        if final_round:
+            episode.messages.append(final_round_message(structured_terminal))
+
+        token_count = estimate_prompt_tokens(episode.messages)
+        if token_count >= PRUNE_REMINDER_TOKENS and not final_round:
+            episode.messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Context budget notice: your current prompt is estimated at "
+                        f"{token_count} tokens, over your context budget. Include "
+                        f"{PRUNE_TOOL_NAME} among your tool calls this round to remove content "
+                        "you no longer need -- it may run in parallel with other tools -- "
+                        "or submit if done."
+                    ),
+                }
+            )
+        if token_count >= HARD_PROMPT_TOKENS:
+            prune_stale_tool_payloads(episode.messages, episode.evidence)
+
+        # Build only non-terminal client schemas; complete() attaches the terminal.
+        schemas = build_tool_schemas(episode.evidence)
+        terminal_tool = (
+            terminal_tool_schema(episode.evidence.visible_chunk_ids())
+            if structured_terminal
+            else None
+        )
+        response = await complete(
+            episode.messages,
+            schemas,
+            final_round=final_round,
+            terminal_tool=terminal_tool,
+        )
+        choice = response.choices[0]
+        message = choice.message
+        calls = list(message.tool_calls or [])
+        episode.trace.append(trace_turn(attempt_index, response))
+
+        terminal_calls = [call for call in calls if call.function.name == TERMINAL_TOOL_NAME]
+        if structured_terminal and terminal_calls:
+            if len(calls) != 1:
+                episode.messages.extend(
+                    terminal_error_messages(
+                        message,
+                        calls,
+                        f"{TERMINAL_TOOL_NAME} must be the only call in its turn",
+                    )
+                )
+                terminal_corrections += 1
+                if terminal_corrections > MAX_TERMINAL_CORRECTIONS:
+                    break
+                force_terminal = True
+                continue
+            try:
+                submission = validate_terminal(terminal_calls[0], episode.evidence)
+            except (TypeError, ValueError) as exc:
+                episode.messages.extend(
+                    terminal_error_messages(message, calls, str(exc))
+                )
+                terminal_corrections += 1
+                if terminal_corrections > MAX_TERMINAL_CORRECTIONS:
+                    break
+                force_terminal = True
+                continue
+            return {"submission": submission, "trace": episode.trace}
+
+        if not calls:
+            # A finished run arrives as assistant text, never as a tool call.
+            if not structured_terminal and choice.finish_reason == "stop" and message.content:
+                return {"answer": message.content, "trace": episode.trace}
+            if structured_terminal and choice.finish_reason == "stop" and message.content:
+                # The model considers itself done but answered in prose. Force the
+                # structured terminal instead of accepting an unstructured answer.
+                # This failed ending consumes the same bounded correction budget as
+                # an invalid terminal payload.
+                episode.messages.append(message.model_dump(exclude_none=True))
+                terminal_corrections += 1
+                if terminal_corrections > MAX_TERMINAL_CORRECTIONS:
+                    break
+                force_terminal = True
+                continue
+            if final_round:
+                episode.messages.append(message.model_dump(exclude_none=True))
+                terminal_corrections += 1
+                if terminal_corrections > MAX_TERMINAL_CORRECTIONS:
+                    break
+                force_terminal = True
+            continue
+
+        if final_round:
+            episode.messages.extend(
+                terminal_error_messages(
+                    message,
+                    calls,
+                    "final correction turns may contain only the terminal call",
+                )
+            )
+            terminal_corrections += 1
+            if terminal_corrections > MAX_TERMINAL_CORRECTIONS:
+                break
+            force_terminal = True
+            continue
+
+        episode.messages.append(message.model_dump(exclude_none=True))
+        tool_messages = await execute_round(episode, calls)
+        tool_messages = budget_and_register(tool_messages, episode.evidence)
+        if len(tool_messages) != len(calls):
+            raise AssertionError("budgeting must preserve one message per tool call")
+        episode.messages.extend(tool_messages)
+
+    raise RuntimeError("the model did not produce a valid terminal after bounded corrections")
+```
+
+Every tool call returns as `finish_reason="tool_calls"`, and the next API request must replay the assistant message plus one matching tool message per call.
+
+Leave `structured_terminal` off when the user-ready answer is the artifact; the model supplies it as text. Turn it on when the caller needs validated evidence IDs, scores, or any other structured payload, and accept the round it costs: the model still tends to end in prose, so the harness records that assistant message, charges it against the bounded correction budget, appends a persistent user correction, and forces the terminal rather than accepting unstructured output.
+
+## Evidence registry invariants
+
+Implement these invariants even if the surrounding class differs:
+
+- Allocate one short handle per corpus chunk identity and never reassign it.
+- Deduplicate ordinary search results against the agent's seen set before returning them.
+- Clip text before serializing the tool result.
+- Clip or replace oversized tool-message content, but never drop the message envelope for an emitted call.
+- Register only results actually kept after round-budget truncation.
+- Mark pruned evidence separately from unseen/discarded evidence.
+- Expose currently visible chunk IDs so each terminal schema can constrain submissions to evidence the model was shown.
+- Allow the chunk-expansion tool to restore pruned content, but reject unknown handles.
+- Build the terminal's `chunk_id` enum from IDs the model was shown, and still validate the submission against the registry.
+- Resolve the final ranking strictly from the registry; do not replace an invalid or missing submission with search-score order.

--- a/skills/mixedbread-search-agent-harness/references/reference-harness.md
+++ b/skills/mixedbread-search-agent-harness/references/reference-harness.md
@@ -1,0 +1,71 @@
+# What Mixedbread's own harness does
+
+Behaviors from the harness Mixedbread runs in production against this model. Numbers are tuned starting points, not limits of the model.
+
+## Signal context pressure to the model
+
+The harness never prunes silently and never waits for the ceiling. The system prompt sets the contract before any pressure exists:
+
+> Call prune_context to remove chunk content irrelevant to your assigned aspect. Keep the context window small; you have a limited token budget.
+
+Every round past the trigger then carries a user message:
+
+> Context budget notice: your current prompt is estimated at 63400 tokens, over your context budget. Include prune_context among your tool calls this round to remove content you no longer need -- it may run in parallel with other tools -- or call submit_ranking if you are done.
+
+| Clause | Why it is there |
+|--------|-----------------|
+| A concrete token count | The model weighs a number against the evidence it holds; "running low" gives it nothing |
+| The tool named | No inference required |
+| "May run in parallel with other tools" | Without it the model burns a whole turn pruning and searching nothing |
+| "Or call submit_ranking if you are done" | Finishing is the other correct response to pressure |
+| Identical at every pressure level | Escalating wording teaches the model to wait for the loud version |
+
+Also: pruning counts toward the parallel-call cap, so say so in the system prompt or the model plans a round that gets rejected. And a round past the trigger with neither a prune nor a submission is recorded and scored — signaling pressure is worth nothing if nothing measures the response.
+
+State the persistence rule, which differs by harness shape:
+
+| Shape | Rule |
+|-------|------|
+| One-shot searcher | Pruned chunks stay in the seen index, never return from normal search; only expansion restores content |
+| Multi-turn conversation | The prune list clears on the next user message, so pruned chunks may resurface as fresh results |
+
+## Label rounds without instructing
+
+From round 2 on, a bare marker follows the previous round's tool results:
+
+```
+Search round 2 of max 4.
+```
+
+"of max", not "of" — a bound the model may stop short of, not a quota. No instruction attached: a per-round nudge to submit teaches it to wait for the countdown instead of stopping when the evidence is sufficient.
+
+## Other behaviors
+
+| Behavior | Detail |
+|----------|--------|
+| Bootstrap | Metadata facets + one seed search on the original query, fetched concurrently before round 1 and injected as tool results in stable facets-then-search order |
+| Spread truncation | Oversized calls truncate in presentation order, earlier results keep more, every item keeps a 512-token floor, nothing is deferred |
+| Grep windows | ±100 tokens around **every** match, not a head clip |
+| Expansion clip | 4× the search clip, so expansion is worth calling |
+| Published bounds | "maximum 20 chunk ids" in the description; without it the model guesses and the call is rejected |
+| Prefix stability | Runtime date is a UTC date, never a clock time (tested: 00:00:01 and 23:59:59 of one day produce identical strings); prompt-rendered scores rounded to 2 significant figures without mutating the results |
+| Width over depth | Raise parallel calls before rounds — a round already costs its slowest call |
+| Terminal failure | Append the assistant message, a tool error, and a correction naming the validation error; retry twice, then return no ranking |
+| Metadata gating | Filters only from bootstrap facets, an inspection result, or metadata on retrieved results; numeric ranking only on confirmed numeric fields |
+| Score comparison | Scores from different tools are not comparable — rank by intent and evidence, not raw score |
+
+## Numbers at a glance
+
+| Knob | Value | Note |
+|------|------:|------|
+| Searcher rounds | 4 | Submit turn included |
+| Parallel calls per round | 8 | Pruning counts toward it |
+| Chunk clip, search tools | 2,000 tokens | |
+| Chunk clip, expansion tools | 8,000 tokens | 4× search |
+| Grep match window | ±100 tokens | Around every match |
+| Per-call payload ceiling | 30,000 / 40,000 / 32,000 | Semantic / metadata listing / expansion; sized so a default-shaped call never clips |
+| Prune trigger | 50,000 | Notice fires every round past it |
+| Hard prompt ceiling | 100,000 tokens | Round payloads truncate to stay under |
+| Per-round payload ceiling | 96,000 tokens | Effective bound is usually headroom |
+| Minimum item allocation | 512 tokens | Floor under spread truncation |
+| Terminal retries | 2 | Then fail explicitly |

--- a/skills/mixedbread-search-agent-harness/references/tool-contracts.md
+++ b/skills/mixedbread-search-agent-harness/references/tool-contracts.md
@@ -1,0 +1,203 @@
+# Tool contracts for the search model
+
+The contracts the model was trained against, expressed against no particular retrieval engine — wire them to whatever backend the harness sits in front of. For the loop that calls these tools, see [python-loop.md](python-loop.md); for the API surface underneath, use the `mixedbread-search-agent` skill.
+
+Every tool name here is illustrative — the harness owns its tool namespace and should name tools for its domain. The one exception is `submit_answer`, which Mixedbread reserves: declaring it fails with HTTP 422.
+
+## How the model reads a tool
+
+| Write | Because |
+|-------|---------|
+| The matching mechanism, named explicitly | The model picks between primitives on stated contrast, not implied |
+| The preferred input form | "Human-style question" and "keyword-heavy, not questions" produce different queries |
+| One contrasting misuse + the tool to use instead | Redirects the failure rather than just forbidding it |
+| Bounds, in the description | Without a published max the model guesses and the whole call is rejected |
+| What comes back | Handles it can reference later |
+
+Arguments: flat, snake_case, JSON-native (`str`, `float`, `bool`, `list[str]`, at most one level of typed dict). `Literal`/enum for closed choices. Only essentials required, defaults for the rest.
+
+In Python the docstring becomes the tool description and `Annotated` strings become parameter descriptions. The raw API always takes explicit JSON schema.
+
+## Semantic search
+
+```python
+from typing import Annotated
+
+
+def semantic_search(
+    query: Annotated[str, "Natural-language query for a single search aspect; "
+                          "avoid Boolean syntax, regex, and keyword dumps."],
+    top_k: Annotated[int, "Number of chunks to return, max 20."] = 5,
+) -> dict:
+    """Execute a meaning-based semantic search query over the corpus and return the
+    most relevant chunks. Use natural language; phrase queries as human-style
+    questions. Do not use for keyword, regex, or literal-string matching.
+    Returns up to top_k chunks with stable chunk_id handles."""
+    hits = my_search_backend(query, top_k=top_k)  # your implementation
+    return {
+        "query": query,
+        "candidate_count": len(hits),
+        "results": [
+            {"chunk_id": h.id,               # short stable handle, e.g. "c12"
+             "score": round(h.score, 4),
+             "text": h.text,                 # clipped, not the whole document
+             "metadata": h.metadata}
+            for h in hits
+        ],
+    }
+```
+
+As explicit schema for the raw API:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "semantic_search",
+    "description": "Execute a meaning-based semantic search query over the corpus and return the most relevant chunks. Use natural language; phrase queries as human-style questions. Do not use for keyword, regex, or literal-string matching. Returns up to top_k chunks with stable chunk_id handles.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {"type": "string", "description": "Natural-language query for a single search aspect; avoid Boolean syntax, regex, and keyword dumps."},
+        "top_k": {"type": "integer", "description": "Number of chunks to return, max 20.", "default": 5}
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+The model writes human-style questions here, one aspect per query, and fans several out in parallel. Back it with the strongest retrieval available — late-interaction suits the model best, and a reranker materially improves what it sees.
+
+## BM25 keyword search
+
+```python
+def bm25_search(
+    query: Annotated[str, "Space-separated keywords, no natural-language questions, "
+                          "no boolean operators. Example: 'jordan international goals caps'"],
+    top_k: Annotated[int, "Number of chunks to return, max 20."] = 10,
+    mode: Literal["chunks", "documents"] = "chunks",
+) -> dict:
+    """Keyword-based BM25 search over the corpus. This tool matches keywords only —
+    send keyword-heavy queries, not questions. Use for rare terms, names, codes,
+    and exact vocabulary; use the semantic search tool for meaning-based queries.
+    Returns up to top_k chunks with stable chunk_id handles."""
+```
+
+Never label BM25 or any lexical retrieval as semantic.
+
+## Regex grep
+
+| Argument | Type | Notes |
+|----------|------|-------|
+| `pattern` | `str` | Name the actual dialect (RE2, PCRE) in the description |
+| `targets` | `list[Literal["text", "generated"]]` | Default both when OCR/transcription is stored separately |
+| `case_sensitive` | `bool = False` | |
+| Filters | optional | Verified fields only |
+
+Description: "Literal regular-expression matching; no embeddings, semantic match, or reranker. Use for exact tokens, codes, identifiers, function names, SKUs, and quoted phrases."
+
+Return a short window around **every** match, not a head clip — the matched token is why the chunk came back.
+
+## Metadata facets and listing
+
+Facets return real field paths, representative values, value types, and counts. State in the description that samples are representative, not exhaustive enums. Expose facets before any filtering tool: filters on non-existent keys return nothing rather than erroring.
+
+Listing arguments:
+
+| Argument | Type | Notes |
+|----------|------|-------|
+| `filter_by` | flat conditions: `key`, enum `operator`, JSON-native `value` | Build any nested tree yourself |
+| `filter_mode` | `Literal["all", "any"] = "all"` | |
+| `rank_by` | `str \| None` | Confirmed numeric fields only |
+| `direction` | `Literal["asc", "desc"] = "desc"` | |
+| `top_k` | bounded int | |
+
+Apply non-negotiable scope — tenant, permissions, collection — as a filter the model cannot see or override. Report whether numeric ranking was applied and how many values were non-numeric; never let a bad sort field crash the episode.
+
+## Expansion tools
+
+| Tool | Arguments | Contract |
+|------|-----------|----------|
+| Chunk expansion | `chunk_ids: list[str]` | Exact previously emitted handles; publish a max list size |
+| Neighbor window | `chunk_id: str, before: int, after: int` | Bounded window around one result |
+
+Both reject unknown IDs as structured data and preserve the original handles. Return meaningfully more text than search (~4× the clip) or the model has no reason to call them.
+
+## Prune tool
+
+Nothing prunes for you. Prune-style removal beats summarizing compaction, which invalidates the stable prefix and loses evidence detail. Exposing pruning as a tool lets the model shed evidence it has judged irrelevant; instruct it to call the tool as it approaches the limit.
+
+```json
+{"name": "prune_context", "arguments": {"chunk_ids": ["c2", "c9"], "document_ids": ["d7"]}}
+```
+
+Require at least one emitted ID. Return what was pruned and which IDs were invalid. Pruning removes content, not identity — keep handles resolvable so the model can still rank or restore that evidence.
+
+## Terminal tool
+
+By default the model ends by answering: `finish_reason="stop"` with assistant content and no tool call. When prose is the deliverable, that is the whole terminal contract.
+
+For structured output, define your own terminal under any name except `submit_answer` and force it by name on the final round. The trained shape is chunk IDs your tools emitted, a relevance score each, and short reasoning:
+
+```json
+{
+  "answer": "Complete answer grounded in the retrieved evidence",
+  "ranking_strategy": "How relevance and constraints determined the order",
+  "chunks": [
+    {"chunk_id": "c12", "relevance_score": 0.97},
+    {"chunk_id": "c4", "relevance_score": 0.82}
+  ]
+}
+```
+
+| Requirement | Detail |
+|-------------|--------|
+| `answer` | Complete user-ready text, grounded in retrieved evidence only |
+| `relevance_score` | `[0, 1]` when ranked chunks are part of the task |
+| `chunk_id` | Enum of currently visible IDs; validate against the registry anyway |
+| Count | `minItems`/`maxItems` for strict top-k, plus how to fill a weak tail; otherwise let the model choose and avoid padding |
+| Placement | The only call in its turn; deduplicate IDs |
+
+```python
+tool_choice={"type": "function", "function": {"name": "report_evidence"}}
+```
+
+Without named forcing the model usually just answers in prose. `tool_choice="required"` does not fix it.
+
+For a lookup subagent, the same tool carries a short rationale plus ranked chunks — the parent already has the evidence, so the rationale explains why those chunks answer the assigned aspect.
+
+## Result envelope and stable handles
+
+Every retrieval tool returns a dict, never prose:
+
+```json
+{
+  "query": "Which contract governed the 2019 distribution agreement?",
+  "candidate_count": 5,
+  "results": [
+    {"chunk_id": "c12", "document_id": "d4", "score": 0.8123,
+     "text": "clipped evidence", "metadata": {"year": 2019}}
+  ]
+}
+```
+
+Echo the query or pattern, report candidates remaining after deduplication, sort in presentation order, clip text to ~2,000 tokens.
+
+| Handle rule | Why |
+|-------------|-----|
+| Map real identity → short handle (`c12`) at first sight, never reassign | The model ranks and re-references short handles far more reliably than UUIDs |
+| Any tool taking IDs accepts exactly the IDs you emitted | Otherwise it invents plausible ones |
+| Deduplicate against what the agent has seen | Nothing does cross-call dedup for you |
+| Keep full identity application-side, keyed by handle | That mapping is your provenance and your terminal validator |
+
+## Error envelope
+
+Return errors as data, never raise — validation, backend, timeout, permission, and unknown-ID failures alike:
+
+```json
+{"error": "date must be ISO format, got '3/5/24'", "code": "invalid_arguments", "retryable": true}
+```
+
+Return it as the tool message for the same `tool_call_id`. The model recovers on the next round when the error names the exact field that was wrong, and never recovers from an exception that escapes the executor.

--- a/skills/mixedbread-search-agent/SKILL.md
+++ b/skills/mixedbread-search-agent/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: mixedbread-search-agent
+description: >-
+  Call Mixedbread's Toast-1 search model through the OpenAI-compatible Chat Completions API.
+  Use when authenticating against the Mixedbread completions endpoint, setting request parameters,
+  declaring function tools and answering tool calls, forcing a structured terminal, streaming
+  responses, continuing stored conversations with previous_completion_id, or debugging completions
+  errors such as reserved tool names, context overflow, or SDK extension fields.
+---
+
+# Mixedbread Search Agent
+
+Toast-1 is Mixedbread's search model: a deep search and lookup agent that fans out parallel searches, phrases its own queries across languages, recovers from tool errors, and stops when the evidence is sufficient. It is served over an OpenAI-compatible Chat Completions endpoint.
+
+Toast-1 has no retrieval of its own. Every tool is a Chat Completions `function` your application declares, executes, and feeds back, so the corpus can live in Mixedbread Stores, a vector DB, Elasticsearch, SQL, or the filesystem.
+
+Docs: https://www.mixedbread.com/docs/agent/chat-completions
+Model card: https://www.mixedbread.com/docs/agent/models
+Agent-readable docs: https://www.mixedbread.com/docs/llms.txt
+
+## Authentication
+
+Get an API key at https://platform.mixedbread.com/platform?next=api-keys, then:
+
+```bash
+export MXBAI_API_KEY=mxb_xxxxx
+```
+
+**Pass the key explicitly.** The OpenAI SDKs default to `OPENAI_API_KEY` and know nothing about `MXBAI_API_KEY`; without an explicit `api_key`/`apiKey` the client either sends the wrong key or raises a missing-credentials error at construction.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.mixedbread.com/v1",
+    api_key=os.environ["MXBAI_API_KEY"],
+)
+```
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  baseURL: 'https://api.mixedbread.com/v1',
+  apiKey: process.env.MXBAI_API_KEY!,
+});
+```
+
+The endpoint is `POST https://api.mixedbread.com/v1/chat/completions`, so the base URL keeps the `/v1`. Any Chat Completions-compatible client works if it allows a custom base URL and an escape hatch for extension fields.
+
+## Making a request
+
+```python
+completion = client.chat.completions.create(
+    model="toast-1",
+    messages=[{"role": "user", "content": "Which contract governs the 2019 agreement?"}],
+    tools=TOOLS,
+    temperature=0.7,
+    top_p=0.95,
+    parallel_tool_calls=True,
+    store=False,
+)
+
+message = completion.choices[0].message
+if message.tool_calls:
+    ...          # execute them, append results, send the next request
+else:
+    print(message.content)     # finish_reason == "stop": the run is done
+```
+
+| Parameter | Send | Notes |
+|-----------|------|-------|
+| `model` | `"toast-1"` | The served search model |
+| `messages` | Full history, every request | The endpoint is stateless |
+| `temperature` / `top_p` | `0.7` / `0.95` | Trained defaults; configurable |
+| `tools` | Your `function` schemas | No built-in retrieval |
+| `tool_choice` | `"auto"`, or a named function | Named forcing is the only route to a structured terminal |
+| `parallel_tool_calls` | `true` | The model fans out by design |
+| `max_completion_tokens` | `4096` or less | Generation is capped at 4,096 tokens |
+| `store` | `false`, or `true` to continue later | Stored completions are retrievable by conversation |
+| `previous_completion_id` | Extension field | Python needs `extra_body`; Node takes it inline |
+| `stream` | Optional | Deltas carry `content` and `reasoning_content` |
+
+## Reading the response
+
+| Field | Value |
+|-------|-------|
+| `choices[0].finish_reason` | `"tool_calls"` — execute and continue; `"stop"` — the answer is in `content` |
+| `choices[0].message.content` | The answer text, on `"stop"` |
+| `choices[0].message.tool_calls[]` | `id`, `function.name`, `function.arguments` (a JSON **string**) |
+| `choices[0].message.reasoning_content` | Search narration for display. Not the answer, not a place to hang logic |
+| `id` | Pass as `previous_completion_id` on the next request when `store=True` |
+| `usage` | Prompt and completion tokens |
+
+Read `reasoning_content` defensively in Python — the SDK may park it in the extras bag:
+
+```python
+narration = getattr(message, "reasoning_content", None) or (message.model_extra or {}).get("reasoning_content")
+```
+
+## Tool calls
+
+Tools are ordinary `function` schemas. What to declare and how to describe them is in [tool-contracts.md](references/tool-contracts.md); backing them with Mixedbread Stores is in [mixedbread-tools.md](references/mixedbread-tools.md).
+
+`finish_reason="tool_calls"` means the model is waiting on you. Append the assistant message, then exactly one `tool` message per `tool_call_id` — including for calls you rejected or that failed. An assistant tool call with no matching `tool` message makes the next request invalid.
+
+Serialize results as JSON, never prose, and return failures as data: a tool that raises past the executor leaves its call unanswered and breaks the next request, while `{"error": "..."}` lets the model correct itself on the following round.
+
+```python
+messages.append(message.model_dump(exclude_none=True))
+for call in message.tool_calls:
+    try:
+        result = IMPLEMENTATIONS[call.function.name](**json.loads(call.function.arguments or "{}"))
+    except Exception as exc:            # never let a tool raise past the executor
+        result = {"error": str(exc), "retryable": True}
+    messages.append({"role": "tool", "tool_call_id": call.id, "content": json.dumps(result)})
+```
+
+```typescript
+messages.push(message);
+for (const call of message.tool_calls ?? []) {
+  let result;
+  try {
+    result = await run(call);
+  } catch (error) {
+    result = {
+      error: error instanceof Error ? error.message : String(error),
+      retryable: true,
+    };
+  }
+  messages.push({
+    role: 'tool',
+    tool_call_id: call.id,
+    content: JSON.stringify(result),
+  });
+}
+```
+
+## Structured terminals
+
+The model ends in prose by default. For ranked evidence or a JSON payload, declare a reporting function under any name except the reserved `submit_answer`, and force it by name:
+
+```python
+final = client.chat.completions.create(
+    model="toast-1",
+    messages=[*messages, {"role": "user", "content": "Do not search further. Report the answer now."}],
+    tools=[report_evidence],
+    tool_choice={"type": "function", "function": {"name": "report_evidence"}},
+    parallel_tool_calls=False,
+    store=False,
+)
+submission = json.loads(final.choices[0].message.tool_calls[0].function.arguments)
+```
+
+Prompt wording alone loses to a prose ending most of the time, and `tool_choice="required"` produces no visible call.
+
+## Stored conversations
+
+```python
+first = client.chat.completions.create(model="toast-1", messages=messages, tools=TOOLS, store=True)
+messages.append(first.choices[0].message.model_dump(exclude_none=True))
+messages.append({"role": "user", "content": "And when does it expire?"})
+
+second = client.chat.completions.create(
+    model="toast-1", messages=messages, tools=TOOLS, store=True,
+    extra_body={"previous_completion_id": first.id},
+)
+```
+
+```typescript
+// Node takes extension fields inline — there is no extra_body option.
+const second = await client.chat.completions.create({
+  model: 'toast-1', messages, tools, store: true,
+  previous_completion_id: first.id,
+} as never);
+```
+
+| Rule | Detail |
+|------|--------|
+| Send the full history anyway | `previous_completion_id` restores hidden prior context; it does not replace `messages` |
+| Requires `store=True` on the prior call | Otherwise there is nothing to restore |
+| Only extends unchanged history | A pruned or edited history silently falls back to stateless text-only mode |
+| Edits win | If the supplied history contradicts the stored one, the supplied history is used |
+| Deletion is chain-wide | Deleting any completion joined by `previous_completion_id` destroys the rest of that thread |
+
+## Streaming
+
+```python
+stream = client.chat.completions.create(
+    model="toast-1", messages=messages, tools=TOOLS, stream=True, store=False,
+)
+for chunk in stream:
+    for choice in chunk.choices:            # some chunks arrive with choices == []
+        narration = getattr(choice.delta, "reasoning_content", None) or (
+            getattr(choice.delta, "model_extra", None) or {}
+        ).get("reasoning_content")
+        if narration:
+            show_narration(narration)
+        if choice.delta.content:
+            show_answer(choice.delta.content)
+```
+
+Streamed tool calls arrive as `delta.tool_calls` fragments and must be accumulated by index before execution. Empty `choices` lists are normal, so guard every access rather than dropping the chunk.
+
+## Limits
+
+| Limit | Value | Consequence |
+|-------|-------|-------------|
+| Sequence length | 131,072 tokens | Keep each request's input under ~130,000 |
+| Generation | Capped at 4,096 tokens per completion | Size the terminal payload to fit |
+| Overflow | Opaque HTTP 500 | Not a context-length error — clip tool results before appending them |
+| Thinking | Disabled | Trained and served without it; `reasoning_content` is display narration only |
+| `submit_answer` | Reserved tool name | Declaring it fails with HTTP 422 |
+| Context management | None | The API prunes nothing; the history you send is the context |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 / invalid API key | Client fell back to `OPENAI_API_KEY` | Pass `api_key`/`apiKey` explicitly |
+| 404 on the request | Base URL missing `/v1` | `https://api.mixedbread.com/v1` |
+| HTTP 422 `'submit_answer' is reserved` | Declared a tool with the reserved name | Rename your terminal |
+| `TypeError: unexpected keyword argument` | Extension passed at the top level in Python | Move it into `extra_body` |
+| Opaque HTTP 500 | Input over the sequence length | Keep the input under ~130,000 tokens; clip tool results before appending them |
+| `422 status code (no body)` in Node | The SDK discards the error body | Wrap `fetch` and log `response.clone().text()` on failure — it names the field at fault |
+| Next request rejected as invalid | An assistant tool call has no matching `tool` message | Emit one per `tool_call_id`, including for rejected calls |
+| Terminal returns prose, no structured payload | Relied on the prompt or `tool_choice="required"` | Force the terminal by name |
+| Loop never terminates | Termination detected by tool name | Detect `finish_reason="stop"` with content |
+| `previous_completion_id` seems ignored | History pruned or edited, or prior call used `store=False` | It only extends unchanged stored history |
+| Deleting one turn wiped the thread | Deletion acts on the whole chain | Completions joined by `previous_completion_id` delete together |
+| `TypeError` on `function.arguments` | Treated as a dict | It is a JSON string — parse it |
+
+## References
+
+- [tool-contracts.md](references/tool-contracts.md) — read before writing any tool schema: primitives, description patterns, result envelope, stable handles, error envelope, terminal tools. Backend-agnostic.
+- [mixedbread-tools.md](references/mixedbread-tools.md) — read when backing tools with Mixedbread Stores: the call behind each primitive, filters, chunk identity, gotchas.

--- a/skills/mixedbread-search-agent/agents/openai.yaml
+++ b/skills/mixedbread-search-agent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mixedbread Search Agent"
+  short_description: "Call Toast-1 over the Completions API"
+  default_prompt: "Use $mixedbread-search-agent to call Mixedbread's Toast-1 search model through the Chat Completions API with your own function tools."

--- a/skills/mixedbread-search-agent/references/mixedbread-tools.md
+++ b/skills/mixedbread-search-agent/references/mixedbread-tools.md
@@ -1,0 +1,163 @@
+# Backing the tools with Mixedbread Stores
+
+Stores are a natural backend for this model: the semantic endpoint is late-interaction retrieval with an optional reranker, and grep, listing, facets, and chunk retrieval cover the remaining primitives.
+
+Read [tool-contracts.md](tool-contracts.md) for the schemas, envelopes, and descriptions; SKILL.md for the API. This is only the wiring. For building the Stores themselves, use the `mixedbread-search` skill.
+
+## Which call backs which tool
+
+| Tool you define | Backing call | Matches on |
+| --- | --- | --- |
+| `semantic_search` | `stores.search()` | Meaning and paraphrase |
+| `grep_search` | `POST /v1/stores/grep` | RE2 regex, literal tokens |
+| `list_chunks` | `POST /v1/stores/list-chunks` | Metadata filters, numeric order |
+| `metadata_facets` | `stores.metadata_facets()` | Nothing — it describes the corpus |
+| `expand_chunks` | `stores.files.retrieve()` | Known chunk identity |
+
+Pin `store_identifiers` inside the implementation from application config. Leaving it out of the tool schema entirely removes hallucinated store names as a failure mode; expose a store argument only when the model genuinely must choose, and pair it with `stores.list()` so it can discover real names.
+
+## Client setup
+
+The `mixedbread` SDK is a second client alongside the OpenAI-compatible one; it runs inside your tool implementations, not in the loop.
+
+```bash
+pip install mixedbread          # Python
+npm install @mixedbread/sdk     # TypeScript
+```
+
+```python
+from mixedbread import Mixedbread
+
+mxbai = Mixedbread()                       # reads MXBAI_API_KEY
+STORE_IDENTIFIERS = ["contracts"]
+```
+
+```ts
+import { Mixedbread } from '@mixedbread/sdk';
+
+const mxbai = new Mixedbread();
+const STORE_IDENTIFIERS = ['contracts'];
+```
+
+## Semantic search
+
+```python
+def semantic_search(query: str, top_k: int = 5) -> dict:
+    response = mxbai.stores.search(
+        query=query,
+        store_identifiers=STORE_IDENTIFIERS,
+        top_k=min(top_k, 20),
+        search_options={"rerank": True},
+    )
+    return envelope(query, [chunk.model_dump() for chunk in response.data])
+```
+
+```ts
+const response = await mxbai.stores.search({
+  query,
+  store_identifiers: STORE_IDENTIFIERS,
+  top_k: Math.min(topK, 20),
+  search_options: { rerank: true },
+});
+```
+
+Keep `rerank` on for production retrieval; it materially improves what the model sees.
+
+Do not combine it with `search_options={"agentic": True}`. Agentic search runs Mixedbread's own Toast-1 harness inside the Search API — it is an alternative to building this loop, not a component of it. Reach for it when you want the model's search behavior with no harness of your own, and for the completions loop when you need control over tools, rounds, or output shape.
+
+## Grep
+
+`POST /v1/stores/grep` has no dedicated SDK method yet. Call it through the SDK's generic `post`, which keeps auth, retries, and base URL handling:
+
+```python
+def grep_search(pattern: str, top_k: int = 10) -> dict:
+    response = mxbai.post(
+        "/v1/stores/grep",
+        body={
+            "pattern": pattern,
+            "store_identifiers": STORE_IDENTIFIERS,  # exactly one store per call
+            "targets": ["text", "generated"],
+            "case_sensitive": False,
+            "top_k": top_k,
+        },
+        cast_to=object,
+    )
+    return envelope(pattern, response.get("data", []))
+```
+
+```ts
+const response = await mxbai.post<{ data: Chunk[] }>('/v1/stores/grep', {
+  body: { pattern, store_identifiers: STORE_IDENTIFIERS, top_k: topK },
+});
+```
+
+- `pattern` is RE2, up to 1024 characters. Say so in the tool description.
+- `targets` defaults to both `text` and `generated`. Keep both unless deliberately excluding ingestion-derived OCR, transcription, and summary fields.
+- One store per call, and no pagination — raise `top_k` for more matches.
+
+## Chunk listing
+
+`POST /v1/stores/list-chunks` selects by metadata instead of by query:
+
+```python
+body = {
+    "store_identifiers": STORE_IDENTIFIERS,  # single store
+    "filters": filters,
+    "top_k": top_k,
+}
+if rank_by:
+    body["sort_by"] = [rank_by, direction == "asc"]
+response = mxbai.post("/v1/stores/list-chunks", body=body, cast_to=object)
+```
+
+`sort_by` takes a field name or `[field, ascending]`. Unprefixed paths target file metadata; `generated_metadata.*` targets chunk metadata. Only sort on numeric fields, and report back how many values were non-numeric or missing rather than failing the call.
+
+## Metadata facets
+
+```python
+facets = mxbai.stores.metadata_facets(store_identifiers=STORE_IDENTIFIERS)
+# {"year": {"2023": 1, "2024": 1}, "author": {"Dana Lee": 1, "Joe Smith": 1}}
+```
+
+Expose this before any filtering tool. Filter keys that do not exist return nothing silently, so facet discovery is what stops a plausible-looking guess from quietly returning zero results.
+
+## Chunk expansion
+
+```python
+file = mxbai.stores.files.retrieve(
+    file_identifier,                    # positional
+    store_identifier=STORE_IDENTIFIERS[0],  # this endpoint accepts one store
+    return_chunks=[3, 4, 5],            # or True for every chunk
+)
+```
+
+Resolve the model's handles to `(file_id, chunk_index)` yourself and validate the range: an index past the end of the file fails with HTTP 422 (`Invalid chunk indices: [0, 1], but must be between 0 and 0`). Clamp and return a structured error instead of letting that reach the model as an exception.
+
+Chunks from this endpoint carry `chunk_index`, `text`, `offset`, and `generated_metadata` but not `file_id` or `filename` — those live on the parent file object, so re-attach them from your registry.
+
+## Filters
+
+Stores filters are a tree with `all` / `any` / `none` combinators:
+
+```python
+filters = {
+    "all": [
+        {"key": "author", "operator": "eq", "value": "Joe Smith"},
+        {"key": "year", "operator": "gte", "value": 2024},
+    ]
+}
+```
+
+Operators: `eq`, `not_eq`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `like`, `not_like`, `contains`, `starts_with`, `regex`.
+
+Give the model a flat condition list plus a `filter_mode: "all" | "any"` and build the tree yourself. Apply non-negotiable application scope as a filter the model cannot see or override, and merge it with whatever the model supplies.
+
+## Chunk identity and available fields
+
+`stores.search`, grep, and list-chunks all return the same chunk shape, so one envelope serves all three. Chunk identity is `(store_id, file_id, chunk_index)` on every retrieval endpoint — map it once to a short handle and keep the mapping on the application side.
+
+Fields available for the envelope: `text`, `score`, `filename`, `file_id`, `store_id`, `chunk_index`, `offset`, `metadata`, `generated_metadata`, `summary`, `context`, `type`, and `mime_type`.
+
+## A cited answer without a loop
+
+`stores.question_answering()` returns generated text with `<cite i="n"/>` tags plus a `sources` list. Use it when a cited answer over one corpus is the whole requirement, and the completions loop when you need custom tools, round control, or a structured terminal.

--- a/skills/mixedbread-search-agent/references/tool-contracts.md
+++ b/skills/mixedbread-search-agent/references/tool-contracts.md
@@ -1,0 +1,203 @@
+# Tool contracts for the search model
+
+The contracts the model was trained against, expressed against no particular retrieval engine. For the Mixedbread Stores wiring, read [mixedbread-tools.md](mixedbread-tools.md); for declaring tools and answering tool calls, see SKILL.md; for running them in a bounded loop, use the `mixedbread-search-agent-harness` skill.
+
+Every tool name here is illustrative — name tools for your domain. The one exception is `submit_answer`, which Mixedbread reserves: declaring it fails with HTTP 422.
+
+## How the model reads a tool
+
+| Write | Because |
+|-------|---------|
+| The matching mechanism, named explicitly | The model picks between primitives on stated contrast, not implied |
+| The preferred input form | "Human-style question" and "keyword-heavy, not questions" produce different queries |
+| One contrasting misuse + the tool to use instead | Redirects the failure rather than just forbidding it |
+| Bounds, in the description | Without a published max the model guesses and the whole call is rejected |
+| What comes back | Handles it can reference later |
+
+Arguments: flat, snake_case, JSON-native (`str`, `float`, `bool`, `list[str]`, at most one level of typed dict). `Literal`/enum for closed choices. Only essentials required, defaults for the rest.
+
+In Python the docstring becomes the tool description and `Annotated` strings become parameter descriptions. The raw API always takes explicit JSON schema.
+
+## Semantic search
+
+```python
+from typing import Annotated
+
+
+def semantic_search(
+    query: Annotated[str, "Natural-language query for a single search aspect; "
+                          "avoid Boolean syntax, regex, and keyword dumps."],
+    top_k: Annotated[int, "Number of chunks to return, max 20."] = 5,
+) -> dict:
+    """Execute a meaning-based semantic search query over the corpus and return the
+    most relevant chunks. Use natural language; phrase queries as human-style
+    questions. Do not use for keyword, regex, or literal-string matching.
+    Returns up to top_k chunks with stable chunk_id handles."""
+    hits = my_search_backend(query, top_k=top_k)  # your implementation
+    return {
+        "query": query,
+        "candidate_count": len(hits),
+        "results": [
+            {"chunk_id": h.id,               # short stable handle, e.g. "c12"
+             "score": round(h.score, 4),
+             "text": h.text,                 # clipped, not the whole document
+             "metadata": h.metadata}
+            for h in hits
+        ],
+    }
+```
+
+As explicit schema for the raw API:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "semantic_search",
+    "description": "Execute a meaning-based semantic search query over the corpus and return the most relevant chunks. Use natural language; phrase queries as human-style questions. Do not use for keyword, regex, or literal-string matching. Returns up to top_k chunks with stable chunk_id handles.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {"type": "string", "description": "Natural-language query for a single search aspect; avoid Boolean syntax, regex, and keyword dumps."},
+        "top_k": {"type": "integer", "description": "Number of chunks to return, max 20.", "default": 5}
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+The model writes human-style questions here, one aspect per query, and fans several out in parallel. Back it with the strongest retrieval available — late-interaction suits the model best, and a reranker materially improves what it sees.
+
+## BM25 keyword search
+
+```python
+def bm25_search(
+    query: Annotated[str, "Space-separated keywords, no natural-language questions, "
+                          "no boolean operators. Example: 'jordan international goals caps'"],
+    top_k: Annotated[int, "Number of chunks to return, max 20."] = 10,
+    mode: Literal["chunks", "documents"] = "chunks",
+) -> dict:
+    """Keyword-based BM25 search over the corpus. This tool matches keywords only —
+    send keyword-heavy queries, not questions. Use for rare terms, names, codes,
+    and exact vocabulary; use the semantic search tool for meaning-based queries.
+    Returns up to top_k chunks with stable chunk_id handles."""
+```
+
+Never label BM25 or any lexical retrieval as semantic.
+
+## Regex grep
+
+| Argument | Type | Notes |
+|----------|------|-------|
+| `pattern` | `str` | Name the actual dialect (RE2, PCRE) in the description |
+| `targets` | `list[Literal["text", "generated"]]` | Default both when OCR/transcription is stored separately |
+| `case_sensitive` | `bool = False` | |
+| Filters | optional | Verified fields only |
+
+Description: "Literal regular-expression matching; no embeddings, semantic match, or reranker. Use for exact tokens, codes, identifiers, function names, SKUs, and quoted phrases."
+
+Return a short window around **every** match, not a head clip — the matched token is why the chunk came back.
+
+## Metadata facets and listing
+
+Facets return real field paths, representative values, value types, and counts. State in the description that samples are representative, not exhaustive enums. Expose facets before any filtering tool: filters on non-existent keys return nothing rather than erroring.
+
+Listing arguments:
+
+| Argument | Type | Notes |
+|----------|------|-------|
+| `filter_by` | flat conditions: `key`, enum `operator`, JSON-native `value` | Build any nested tree yourself |
+| `filter_mode` | `Literal["all", "any"] = "all"` | |
+| `rank_by` | `str \| None` | Confirmed numeric fields only |
+| `direction` | `Literal["asc", "desc"] = "desc"` | |
+| `top_k` | bounded int | |
+
+Apply non-negotiable scope — tenant, permissions, collection — as a filter the model cannot see or override. Report whether numeric ranking was applied and how many values were non-numeric; never let a bad sort field crash the episode.
+
+## Expansion tools
+
+| Tool | Arguments | Contract |
+|------|-----------|----------|
+| Chunk expansion | `chunk_ids: list[str]` | Exact previously emitted handles; publish a max list size |
+| Neighbor window | `chunk_id: str, before: int, after: int` | Bounded window around one result |
+
+Both reject unknown IDs as structured data and preserve the original handles. Return meaningfully more text than search (~4× the clip) or the model has no reason to call them.
+
+## Prune tool
+
+Nothing prunes for you. Prune-style removal beats summarizing compaction, which invalidates the stable prefix and loses evidence detail. Exposing pruning as a tool lets the model shed evidence it has judged irrelevant; instruct it to call the tool as it approaches the limit.
+
+```json
+{"name": "prune_context", "arguments": {"chunk_ids": ["c2", "c9"], "document_ids": ["d7"]}}
+```
+
+Require at least one emitted ID. Return what was pruned and which IDs were invalid. Pruning removes content, not identity — keep handles resolvable so the model can still rank or restore that evidence.
+
+## Terminal tool
+
+By default the model ends by answering: `finish_reason="stop"` with assistant content and no tool call. When prose is the deliverable, that is the whole terminal contract.
+
+For structured output, define your own terminal under any name except `submit_answer` and force it by name on the final round. The trained shape is chunk IDs your tools emitted, a relevance score each, and short reasoning:
+
+```json
+{
+  "answer": "Complete answer grounded in the retrieved evidence",
+  "ranking_strategy": "How relevance and constraints determined the order",
+  "chunks": [
+    {"chunk_id": "c12", "relevance_score": 0.97},
+    {"chunk_id": "c4", "relevance_score": 0.82}
+  ]
+}
+```
+
+| Requirement | Detail |
+|-------------|--------|
+| `answer` | Complete user-ready text, grounded in retrieved evidence only |
+| `relevance_score` | `[0, 1]` when ranked chunks are part of the task |
+| `chunk_id` | Enum of currently visible IDs; validate against the registry anyway |
+| Count | `minItems`/`maxItems` for strict top-k, plus how to fill a weak tail; otherwise let the model choose and avoid padding |
+| Placement | The only call in its turn; deduplicate IDs |
+
+```python
+tool_choice={"type": "function", "function": {"name": "report_evidence"}}
+```
+
+Without named forcing the model usually just answers in prose. `tool_choice="required"` does not fix it.
+
+For a lookup subagent, the same tool carries a short rationale plus ranked chunks — the parent already has the evidence, so the rationale explains why those chunks answer the assigned aspect.
+
+## Result envelope and stable handles
+
+Every retrieval tool returns a dict, never prose:
+
+```json
+{
+  "query": "Which contract governed the 2019 distribution agreement?",
+  "candidate_count": 5,
+  "results": [
+    {"chunk_id": "c12", "document_id": "d4", "score": 0.8123,
+     "text": "clipped evidence", "metadata": {"year": 2019}}
+  ]
+}
+```
+
+Echo the query or pattern, report candidates remaining after deduplication, sort in presentation order, clip text to ~2,000 tokens.
+
+| Handle rule | Why |
+|-------------|-----|
+| Map real identity → short handle (`c12`) at first sight, never reassign | The model ranks and re-references short handles far more reliably than UUIDs |
+| Any tool taking IDs accepts exactly the IDs you emitted | Otherwise it invents plausible ones |
+| Deduplicate against what the agent has seen | Nothing does cross-call dedup for you |
+| Keep full identity application-side, keyed by handle | That mapping is your provenance and your terminal validator |
+
+## Error envelope
+
+Return errors as data, never raise — validation, backend, timeout, permission, and unknown-ID failures alike:
+
+```json
+{"error": "date must be ISO format, got '3/5/24'", "code": "invalid_arguments", "retryable": true}
+```
+
+Return it as the tool message for the same `tool_call_id`. The model recovers on the next round when the error names the exact field that was wrong, and never recovers from an exception that escapes the executor.

--- a/skills/mixedbread-search/SKILL.md
+++ b/skills/mixedbread-search/SKILL.md
@@ -84,7 +84,7 @@ const results = await mxbai.stores.search({
 - **What kind of retrieval do you need?**
   - Simple keyword/semantic lookup → Standard `search()` with `top_k`
   - Natural-language answer with citations → `question_answering()` (citations are on by default)
-  - Complex multi-hop question → `search()` with `agentic` enabled
+  - Complex multi-hop question or retrieval that benefits from adaptive semantic, exact, metadata, and document-level exploration → `search()` with `agentic` enabled
   - Exact token/regex match (error codes, identifiers, literal phrases) → `POST /v1/stores/grep`. See [Grep and Chunk Listing](#grep-and-chunk-listing-rest).
   - Combine internal docs with live web → Add `"mixedbread/web"` to `store_identifiers`
 - **Do you need metadata filtering?**
@@ -303,10 +303,7 @@ if not result.sources:
         query="Compare the pricing tiers and their feature differences",
         store_identifiers=["my-docs"],
         top_k=10,
-        search_options={
-            "rerank": True,
-            "agentic": {"max_rounds": 3},
-        },
+        search_options={"agentic": True},
     )
 
 print(result.answer)
@@ -316,17 +313,19 @@ for source in result.sources:
 
 ### Agentic Search
 
-For complex questions requiring multi-step retrieval. The system decomposes your query into sub-queries and runs multiple rounds. Works in both `search()` and `question_answering()`.
+For complex questions requiring multi-step retrieval. Enabling `agentic` delegates retrieval and ranking to Mixedbread's managed search-agent harness. It begins with the original query and metadata inspection, then adaptively chooses among semantic search, exact/regex matching, metadata filtering, corpus overview, and chunk or document expansion before submitting a final evidence ranking. It can fan searches out in parallel and deduplicates evidence across calls. Works in both `search()` and `question_answering()`.
+
+The exact internal tool sequence is implementation detail: do not assume a fixed number of generated sub-queries or build client logic around trace tool names. The public response remains the usual ranked chunk list; `question_answering()` uses that list to generate its cited answer.
 
 **Python:**
 ```python
 results = mxbai.stores.search(
     query="Compare the pricing tiers and their feature differences",
     store_identifiers=["product-docs"],
+    top_k=10,
     search_options={
+        "rerank": True,
         "agentic": {
-            "max_rounds": 3,
-            "queries_per_round": 2,
             "instructions": (
                 "Prioritize official pricing pages over blog posts. "
                 "Surface tier names, monthly cost, and included feature lists."
@@ -341,10 +340,10 @@ results = mxbai.stores.search(
 const results = await mxbai.stores.search({
     query: 'Compare the pricing tiers and their feature differences',
     store_identifiers: ['product-docs'],
+    top_k: 10,
     search_options: {
+        rerank: true,
         agentic: {
-            max_rounds: 3,
-            queries_per_round: 2,
             instructions:
                 'Prioritize official pricing pages over blog posts. ' +
                 'Surface tier names, monthly cost, and included feature lists.',
@@ -356,19 +355,21 @@ const results = await mxbai.stores.search({
 #### Agentic options
 
 - `agentic: true` — enable with defaults.
-- `agentic: { ... }` — override individual fields:
-  - `max_rounds` (default `3`, range `1–10`) — maximum retrieval rounds.
-  - `queries_per_round` (default `4`, range `1–10`) — sub-queries generated per round.
-  - `instructions` (string, up to 5000 chars) — the **agent prompt input**. Tells the agent how to plan and rank its searches: which entities, metrics, or source types to prioritize; what to treat as authoritative; what to ignore. The top-level `query` remains the user's question — use `instructions` for guidance that shouldn't appear in every sub-query.
-  - `strict_top_k` (default `false`) — require the final chunk list to contain exactly `top_k` ranked chunks.
-  - `media_content` (default `"auto"`) — when retrieved image content is sent to the agent: `"auto"` only when no OCR text or summary is available, `"never"` disables it, `"always"` sends it whenever available.
+- `agentic: { ... }` — use the currently active request controls:
+  - `instructions` (string, up to 5000 chars) — additional retrieval and ranking guidance. Tell the agent which entities, metrics, time ranges, source types, or authority rules matter and what to ignore. The top-level `query` remains the user's question.
+  - `strict_top_k` (default `false`) — require the final evidence submission to contain exactly `top_k` chunks. Leave this off for small or sparse stores that may not contain enough relevant chunks.
 
-When `agentic` is enabled, `search_options.rewrite_query` and `search_options.rerank` are ignored — the agent handles query decomposition and ranking itself.
+The managed harness honors the top-level `query`, `store_identifiers`, `top_k`, `filters`, and `file_ids`. `filters` and `file_ids` are hard scope constraints ANDed into every retrieval the agent makes, while `instructions` are soft planning and ranking guidance.
+
+The request schema still accepts `max_rounds`, `queries_per_round`, and `media_content` for compatibility with the previous agentic implementation, but the managed harness does not currently forward these request-level values. Do not use them for tuning. Retrieved image content is currently disabled for the managed agent, and request-level `score_threshold` is not forwarded either.
+
+When `agentic` is enabled, `search_options.rewrite_query` is unnecessary because the managed agent plans its own queries. `rerank` may be enabled alongside agentic search; it reranks results returned by the agent's semantic-search tool before the agent performs its final evidence ranking.
 
 #### Writing good agentic `instructions`
 
 - Prefer directive phrases ("prioritize X", "ignore Y", "treat Z as authoritative") over restating the question.
-- Name the concrete fields, metrics, or document types to surface so ranking is grounded in what you care about.
+- Name concrete entities, fields, metrics, time ranges, or document types so exploration and ranking are grounded in what you care about.
+- Use top-level `filters` or `file_ids` for enforceable scope. Do not rely on instructions such as "only search team=growth" when a metadata filter can express the constraint.
 - Keep the question itself in `query`; put ranking/planning guidance in `instructions`.
 
 ## Response Shapes
@@ -436,8 +437,8 @@ for file in files.data:
 ### MEDIUM
 - **Set `expires_after` for temporary stores.** PR review stores, demo stores, and test stores should auto-expire to avoid accumulating unused indexes.
 - **One store per knowledge domain, not per query.** Stores are persistent indexes meant to be reused. Create once, search many times.
-- **Use `score_threshold` to filter low-relevance noise.** Set `search_options: {"score_threshold": 0.3}` to drop chunks below a minimum relevance server-side — no need to post-filter on `chunk.score` client-side.
-- **Start with default `agentic` settings.** Only increase `max_rounds` if results are insufficient.
+- **Use `score_threshold` to filter low-relevance noise in standard search.** Set `search_options: {"score_threshold": 0.3}` to drop chunks below a minimum relevance server-side — no need to post-filter on `chunk.score` client-side. It is not currently forwarded in agentic search.
+- **Use only active agentic controls.** Tune `top_k`, hard-scope with `filters`/`file_ids`, and steer with `agentic.instructions`. Request-level `max_rounds`, `queries_per_round`, and `media_content` are compatibility fields and are not currently forwarded to the managed harness.
 - **Use `agentic.instructions` to steer retrieval, not `query`.** Keep `query` as the user's natural-language question. Put "prioritize X", "ignore Y", source-type preferences, and ranking hints in `search_options.agentic.instructions` (up to 5000 chars).
 - **Image queries only support plain semantic search.** Combining an image query with `rerank`, `rewrite_query`, or `agentic` raises a validation error.
 
@@ -449,5 +450,5 @@ for file in files.data:
 | No results returned | Score cutoff too high | Lower or remove `search_options.score_threshold` (or any client-side cutoff). |
 | No results returned | Wrong `store_identifiers` | Verify the store name or ID matches exactly. |
 | Metadata filters return nothing | Wrong key name or value | Use `metadata_facets()` to discover actual keys and values. |
-| Slow agentic search | Too many rounds or queries | Reduce `max_rounds` or `queries_per_round`. Use standard search if the query is simple. |
+| Slow agentic search | Managed multi-step exploration adds model and retrieval calls | Use standard search if the query is simple, reduce `top_k` when fewer final chunks are sufficient, and make `agentic.instructions` more focused. Do not try to tune compatibility-only `max_rounds` or `queries_per_round`. |
 | API key error | Invalid or missing key | Verify `MXBAI_API_KEY` is set. Get a key at https://platform.mixedbread.com/platform?next=api-keys |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are documentation and plugin metadata only; the main product risk is agents following outdated agentic tuning knobs if the new managed-harness notes are wrong.
> 
> **Overview**
> Adds **two new agent skills** for Mixedbread’s **Toast-1** search model and registers them across Claude/Cursor marketplaces, README, `SKILL_TREE.md`, and `agents/AGENTS.md`. Marketplace metadata moves to **1.1.0** and broadens descriptions to cover completions and harnesses.
> 
> **`mixedbread-search-agent`** documents calling Toast-1 via the OpenAI-compatible Chat Completions API (`toast-1`, explicit `MXBAI_API_KEY`, tool loops, structured terminals, streaming, `previous_completion_id`), plus references for backend-agnostic **tool contracts** and **Stores-backed tool wiring**.
> 
> **`mixedbread-search-agent-harness`** documents building a custom multi-round loop: round/parallel budgets, evidence handles, pruning vs summarization, terminal forcing, and Python/async patterns, with architecture and production-harness reference material.
> 
> **`mixedbread-search`** agentic guidance is **rewritten** to match the **managed Toast-1 harness** inside Stores search: emphasizes `instructions`, `filters`/`file_ids`, and notes that `max_rounds`, `queries_per_round`, and related request fields are compatibility-only; **rerank** can run alongside agentic search.
> 
> **`CLAUDE.md`** gains updated skill-authoring conventions (including full duplicate of shared `tool-contracts.md` across plugins), skill testing via `benchmark.sh`, and distribution/versioning notes; **README** adds `npx skills check` / `update`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5440ca2ae55027b797ade3f7919f4fb439887c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->